### PR TITLE
ci: add CODEOWNERS with team handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tazama-lf/core-codeowners @tazama-lf/community-codeowners


### PR DESCRIPTION
Adds .github/CODEOWNERS file with team handles (@tazama-lf/core-codeowners and @tazama-lf/community-codeowners) to define code ownership.